### PR TITLE
Fix missing semicolon invalidating `font-family`

### DIFF
--- a/medium-theme.md
+++ b/medium-theme.md
@@ -32,7 +32,7 @@ TODOs:
 }
 
 .markdown-body blockquote {
-    font-family: medium-content-title-font, Georgia, Cambria, "Times New Roman", Times, serif
+    font-family: medium-content-title-font, Georgia, Cambria, "Times New Roman", Times, serif;
     padding-left: 30px;
     border: none;
     font-size: 30px;


### PR DESCRIPTION
A semicolon is missing in the rule `.markdown-body blockquote`, which makes the attribute `font-family` invalid.

This pull request fixes the issue.